### PR TITLE
do not allow games where the secret santa can be deterministically deduced

### DIFF
--- a/R/secret_santa.R
+++ b/R/secret_santa.R
@@ -14,7 +14,7 @@ secret_santa <- function(names, seed = 2512) {
     stop("Non-unique names provided - do you need to add a surname?")
   }
 
-  if(length(names) <= 2) {
+  if (length(names) <= 2) {
     stop("It's not a secret with 2 or fewer players")
   }
 

--- a/R/secret_santa.R
+++ b/R/secret_santa.R
@@ -13,6 +13,11 @@ secret_santa <- function(names, seed = 2512) {
   if (anyDuplicated(names)) {
     stop("Non-unique names provided - do you need to add a surname?")
   }
+
+  if(length(names) <= 2) {
+    stop("It's not a secret with 2 or fewer players")
+  }
+
   withr::with_seed(
     seed = seed,
     code = {

--- a/R/secret_santa.R
+++ b/R/secret_santa.R
@@ -14,8 +14,8 @@ secret_santa <- function(names, seed = 2512) {
     stop("Non-unique names provided - do you need to add a surname?")
   }
 
-  if (length(names) <= 2) {
-    stop("It's not a secret with 2 or fewer players")
+  if (length(names) <= 3) {
+    stop("It's not a secret with 3 or fewer players")
   }
 
   withr::with_seed(

--- a/tests/testthat/test-secret_santa.R
+++ b/tests/testthat/test-secret_santa.R
@@ -22,3 +22,11 @@ test_that("secret_santa() warns if the same person appears twice in the list", {
   )
   expect_error(secret_santa(nice_list), "Non-unique names provided")
 })
+
+test_that("secret_santa() warns if the number of players is too small", {
+  nice_list <- c(
+    "Rudolph",
+    "Dasher"
+  )
+  expect_error(secret_santa(nice_list), "It's not a secret with 2 or fewer players")
+})

--- a/tests/testthat/test-secret_santa.R
+++ b/tests/testthat/test-secret_santa.R
@@ -26,7 +26,8 @@ test_that("secret_santa() warns if the same person appears twice in the list", {
 test_that("secret_santa() warns if the number of players is too small", {
   nice_list <- c(
     "Rudolph",
-    "Dasher"
+    "Dasher",
+    "Prancer"
   )
   expect_error(secret_santa(nice_list), "It's not a secret with 3 or fewer players")
 })

--- a/tests/testthat/test-secret_santa.R
+++ b/tests/testthat/test-secret_santa.R
@@ -28,5 +28,5 @@ test_that("secret_santa() warns if the number of players is too small", {
     "Rudolph",
     "Dasher"
   )
-  expect_error(secret_santa(nice_list), "It's not a secret with 2 or fewer players")
+  expect_error(secret_santa(nice_list), "It's not a secret with 3 or fewer players")
 })


### PR DESCRIPTION
`gift_recipient = random_names[c(2:length(random_names), 1)]` will fail if `length(names) <= 1`, however, the secret santa is meaningless for 2 or fewer players, so we should error